### PR TITLE
fix console warning

### DIFF
--- a/src/__tests__/main.test.js
+++ b/src/__tests__/main.test.js
@@ -300,7 +300,9 @@ describe("General Tests", () => {
         voteSum: 0,
       };
       mockRouter.setCurrentUrl(`/posts/1`);
-      render(<ShowPost currentPost={examplePost} />);
+      await waitFor(() => {
+        render(<ShowPost currentPost={examplePost} />);
+      });
       // screen.getByText()
       expect(screen.getByText("Delete Post")).toBeInTheDocument();
     });


### PR DESCRIPTION
this pr fixes the console warning during testing:

`console.error
      Warning: An update to ShowPost inside a test was not wrapped in act(...).
      
      When testing, code that causes React state updates should be wrapped into act(...):
      
      act(() => {
        /* fire events that update state */
      });
      /* assert on the output */
      
      This ensures that you're testing the behavior the user would see in the browser. Learn more at https://reactjs.org/link/wrap-tests-with-act
          at currentPost (/Users/desktop/school/sd/project/project-ellen/src/pages/posts/[id].js:13:36)

      37 |         .then((res) => res.json())
      38 |         .then((response) => {
    > 39 |           setComments(response);
         |           ^
      40 |         });
      41 |     }
      42 |   }, [currentPost]);
`